### PR TITLE
Add coc.nvim and coc-elixir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,0 @@
-coc/extensions/node_modules
-coc/extensions/package-lock.json
-coc/memos.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+coc/extensions/node_modules
+coc/extensions/package-lock.json
+coc/memos.json

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,7 +4,6 @@
 [submodule "pack/plugins/start/vim-dim"]
 	path = pack/plugins/start/vim-dim
 	url = git@github.com:jeffkreeftmeijer/vim-dim.git
-<<<<<<< HEAD
 [submodule "pack/plugins/start/vim-numbertoggle"]
 	path = pack/plugins/start/vim-numbertoggle
 	url = git@github.com:jeffkreeftmeijer/vim-numbertoggle.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,7 @@
 [submodule "pack/plugins/start/vim-dim"]
 	path = pack/plugins/start/vim-dim
 	url = git@github.com:jeffkreeftmeijer/vim-dim.git
+<<<<<<< HEAD
 [submodule "pack/plugins/start/vim-numbertoggle"]
 	path = pack/plugins/start/vim-numbertoggle
 	url = git@github.com:jeffkreeftmeijer/vim-numbertoggle.git
@@ -13,3 +14,6 @@
 [submodule "pack/plugins/start/vim-surround"]
 	path = pack/plugins/start/vim-surround
 	url = git@github.com:tpope/vim-surround.git
+[submodule "pack/plugins/start/coc.nvim"]
+	path = pack/plugins/start/coc.nvim
+	url = git@github.com:neoclide/coc.nvim.git

--- a/.vimrc
+++ b/.vimrc
@@ -22,5 +22,3 @@ let g:netrw_liststyle = 3
 let g:netrw_banner = 0
 " Open files in the previous split
 let g:netrw_browse_split = 4
-
-let g:coc_data_home = "~/.vim/coc"

--- a/.vimrc
+++ b/.vimrc
@@ -22,3 +22,5 @@ let g:netrw_liststyle = 3
 let g:netrw_banner = 0
 " Open files in the previous split
 let g:netrw_browse_split = 4
+
+let g:coc_data_home = "~/.vim/coc"

--- a/.vimrc
+++ b/.vimrc
@@ -19,6 +19,13 @@ endif
 " Install coc.nvim plugins
 let g:coc_global_extensions = ['coc-elixir']
 
+" Use <TAB> to toggle completion suggestions
+inoremap <silent><expr> <TAB>
+      \ pumvisible() ? "\<C-n>" :
+      \ <SID>check_back_space() ? "\<TAB>" :
+      \ coc#refresh()
+inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
+
 " Use netrw's tree view
 let g:netrw_liststyle = 3
 " Hide netrw's help banner (toggle with I)

--- a/.vimrc
+++ b/.vimrc
@@ -16,6 +16,9 @@ if has('nvim')
   let g:polyglot_disabled = ['sensible']
 endif
 
+" Install coc.nvim plugins
+let g:coc_global_extensions = ['coc-elixir']
+
 " Use netrw's tree view
 let g:netrw_liststyle = 3
 " Hide netrw's help banner (toggle with I)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ Back up your own `~/.vim` if you have one, then:
     $ git clone git@github.com:jeffkreeftmeijer/.vim.git ~/.vim
     $ git -C ~/.vim submodule init && git -C ~/.vim submodule update
     $ mkdir -p ~/.config/nvim && ln -s ~/.vim/.vimrc ~/.vimrc && ln -s ~/.vim/.vimrc ~/.config/nvim/init.vim
-    $ npm --prefix ~/.vim/coc/extensions install
 
 ##  Uninstall
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Back up your own `~/.vim` if you have one, then:
     $ git clone git@github.com:jeffkreeftmeijer/.vim.git ~/.vim
     $ git -C ~/.vim submodule init && git -C ~/.vim submodule update
     $ mkdir -p ~/.config/nvim && ln -s ~/.vim/.vimrc ~/.vimrc && ln -s ~/.vim/.vimrc ~/.config/nvim/init.vim
+    $ npm --prefix ~/.vim/coc/extensions install
 
 ##  Uninstall
 


### PR DESCRIPTION
For code completion, compiler checks and dialyzer analysis, we’ll run an Elixir language server, through the coc.nvim plugin.

    $ git submodule add git@github.com:neoclide/coc.nvim.git pack/plugins/start/coc.nvim
    
After installing coc.nvim, we’ll install the elixir language server through a plugin for coc.nvim.

By using the `g:coc_global_extensions` configuration in our `~/.vimrc` file, coc.nvim will automatically install the elixir plugin when we start Vim, if it hasn’t already. 

    " ~/.vimrc
    let g:coc_global_extensions = ['coc-elixir']

Lastly, we’ll add a snippet to automatically select the first autocomplete suggestion when pressing the `<TAB>`-key:

    " ~/.vimrc
    inoremap <silent><expr> <TAB>
      \ pumvisible() ? "\<C-n>" :
      \ <SID>check_back_space() ? "\<TAB>" :
      \ coc#refresh()
    inoremap <expr><S-TAB> pumvisible() ? "\<C-p>" : "\<C-h>"
